### PR TITLE
fixed orb_slam2_ros/ORBState.h error

### DIFF
--- a/ORB_SLAM2/build.sh
+++ b/ORB_SLAM2/build.sh
@@ -1,29 +1,3 @@
-#echo "Configuring and building Thirdparty/DBoW2 ..."
-
-#cd orb_slam2_lib/Thirdparty/DBoW2
-#mkdir build
-#cd build
-#cmake .. -DCMAKE_BUILD_TYPE=Release
-#make -j2
-
-#cd ..
-#cd ../../g2o
-
-#echo "Configuring and building Thirdparty/g2o ..."
-
-#mkdir build
-#cd build
-#cmake .. -DCMAKE_BUILD_TYPE=Release
-#make -j2
-
-#cd ../../..
-
-#echo "Uncompress vocabulary ..."
-
-#cd Vocabulary
-#tar -xf ORBvoc.txt.tar.gz
-#cd ..
-
 echo "Configuring and building ORB_SLAM2 ..."
 
 mkdir build

--- a/ORB_SLAM2/build.sh
+++ b/ORB_SLAM2/build.sh
@@ -1,35 +1,35 @@
-echo "Configuring and building Thirdparty/DBoW2 ..."
+#echo "Configuring and building Thirdparty/DBoW2 ..."
 
-cd orb_slam2_lib/Thirdparty/DBoW2
-mkdir build
-cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release
-make -j
+#cd orb_slam2_lib/Thirdparty/DBoW2
+#mkdir build
+#cd build
+#cmake .. -DCMAKE_BUILD_TYPE=Release
+#make -j2
 
-cd ..
-cd ../../g2o
+#cd ..
+#cd ../../g2o
 
-echo "Configuring and building Thirdparty/g2o ..."
+#echo "Configuring and building Thirdparty/g2o ..."
 
-mkdir build
-cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release
-make -j
+#mkdir build
+#cd build
+#cmake .. -DCMAKE_BUILD_TYPE=Release
+#make -j2
 
-cd ../../..
+#cd ../../..
 
-echo "Uncompress vocabulary ..."
+#echo "Uncompress vocabulary ..."
 
-cd Vocabulary
-tar -xf ORBvoc.txt.tar.gz
-cd ..
+#cd Vocabulary
+#tar -xf ORBvoc.txt.tar.gz
+#cd ..
 
 echo "Configuring and building ORB_SLAM2 ..."
 
 mkdir build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
-make -j
+make -j2
 
 # back to the initial directory i.e. {WS}/src/ORB_SLAM2_ROS/ORB_SLAM2 (not necessary)
 cd ../..

--- a/ORB_SLAM2/build_catkin.sh
+++ b/ORB_SLAM2/build_catkin.sh
@@ -24,7 +24,7 @@ echo "Done"
 echo " "
 sleep 1
 cd ../../../../.. # back to the workspace main folder
-#catkin build octomap_ros
+
 catkin build -j2 orb_slam2_lib
 source devel/setup.bash
 
@@ -37,7 +37,6 @@ cd ../.. # back to the workspace main folder
 
 cd src/ORB-SLAM2_ROS/ORB_SLAM2
 ./build.sh
-#./build_ros.sh
 
 sleep 1
 cd ../../.. # back to the workspace main folder

--- a/ORB_SLAM2/build_catkin.sh
+++ b/ORB_SLAM2/build_catkin.sh
@@ -9,17 +9,6 @@ echo " "
 echo -e "Let this script be the ${CYN}first execution after cleaning workspace${NC} by ${GRN}'catkin clean'${NC} command"
 echo -e "${RED}Be careful!${NC} It will rebuild all packages from workspace"
 echo " "
-echo -e "Installation will start in ${CYN}5${NC}"
-sleep 1
-echo -e "Installation will start in ${CYN}4${NC}"
-sleep 1
-echo -e "Installation will start in ${CYN}3${NC}"
-sleep 1
-echo -e "Installation will start in ${CYN}2${NC}"
-sleep 1
-echo -e "Installation will start in ${CYN}1${NC}"
-sleep 1
-echo " "
 
 echo -e "Trying to install ${GRN}Eigen3${NC} and ${GRN}octomap${NC} packages. You need to write password in order to do that..."
 sleep 1
@@ -35,8 +24,8 @@ echo "Done"
 echo " "
 sleep 1
 cd ../../../../.. # back to the workspace main folder
-catkin build octomap_ros
-catkin build orb_slam2_lib
+#catkin build octomap_ros
+catkin build -j2 orb_slam2_lib
 source devel/setup.bash
 
 echo " "
@@ -48,15 +37,15 @@ cd ../.. # back to the workspace main folder
 
 cd src/ORB-SLAM2_ROS/ORB_SLAM2
 ./build.sh
-./build_ros.sh
+#./build_ros.sh
 
 sleep 1
 cd ../../.. # back to the workspace main folder
 source devel/setup.bash
-catkin build
+catkin build -j2
 source devel/setup.bash
 sleep 3
-catkin build orb_slam2_ros orb_slam2_lib
+catkin build -j2 orb_slam2_ros orb_slam2_lib
 source devel/setup.bash
 sleep 2
 

--- a/ORB_SLAM2/build_ros.sh
+++ b/ORB_SLAM2/build_ros.sh
@@ -4,5 +4,5 @@ cd orb_slam2_ros
 mkdir build
 cd build
 cmake .. -DROS_BUILD_TYPE=Release
-make -j
+make -j2
 cd ../.. # (not necessary)

--- a/ORB_SLAM2/orb_slam2_ros/CMakeLists.txt
+++ b/ORB_SLAM2/orb_slam2_ros/CMakeLists.txt
@@ -26,7 +26,6 @@ find_package(catkin REQUIRED COMPONENTS
 
 # Generate messages in the 'msg' folder
 add_message_files(
-  DIRECTORY msg
   FILES
   ORBState.msg
 )
@@ -36,9 +35,15 @@ generate_messages(
   std_msgs
 )
 
-catkin_package(CATKIN_DEPENDS message_runtime std_msgs)
+catkin_package(
+  INCLUDE_DIRS include
+  #LIBRARIES 
+  CATKIN_DEPENDS message_runtime std_msgs
+  #DEPENDS 
+)
 
 include_directories(
+  ${catkin_INCLUDE_DIRS}
   ${roscpp_INCLUDE_DIRS}
   ${octomap_ros_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIR}
@@ -53,15 +58,21 @@ add_library(PublisherUtils
  ${PROJECT_SOURCE_DIR}/include/PublisherUtils_impl.h
 )
 
+add_dependencies(PublisherUtils ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
 add_library(ScaleCorrector
  ${PROJECT_SOURCE_DIR}/include/ScaleCorrector.h
  ${PROJECT_SOURCE_DIR}/src/ScaleCorrector.cpp
 )
 
+add_dependencies(ScaleCorrector ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
 add_library(ROSSystemBuilder
  ${PROJECT_SOURCE_DIR}/include/ROSSystemBuilder.h
  ${PROJECT_SOURCE_DIR}/src/ROSSystemBuilder.cpp
 )
+
+add_dependencies(ROSSystemBuilder ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 set(LIBS
   ${roscpp_LIBRARIES}
@@ -80,7 +91,7 @@ add_executable(Mono
   src/ROSPublisher.cpp
 )
 
-add_dependencies(Mono ${${PROJECT_NAME}_EXPORTED_TARGETS})
+add_dependencies(Mono ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 target_link_libraries(Mono
   ${LIBS}
@@ -103,7 +114,7 @@ add_executable(Stereo
   src/ROSPublisher.cpp
 )
 
-add_dependencies(Stereo ${${PROJECT_NAME}_EXPORTED_TARGETS})
+add_dependencies(Stereo ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 target_link_libraries(Stereo
   ${LIBS}
@@ -115,10 +126,7 @@ add_executable(RGBD
   src/ROSPublisher.cpp
 )
 
-add_dependencies(Stereo ${${PROJECT_NAME}_EXPORTED_TARGETS})
-
+add_dependencies(RGBD ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(RGBD
   ${LIBS}
 )
-
-


### PR DESCRIPTION
Fixed CMake file for orb_slam2_ros, according to advice here 
https://answers.ros.org/question/209574/why-catkin-do-not-generate-message-headers/
The problem was that the libraries also used ORBState.h for compilation, but that dependency wasn't added for libraries, only for executable files (in orb-state-header-fix branch).